### PR TITLE
Full support for FPU state preservation, refactored assembly code, miscellaneous bug fixes

### DIFF
--- a/src/utility/hook.cpp
+++ b/src/utility/hook.cpp
@@ -84,7 +84,7 @@ namespace hook
     }
 
    uint64_t get_xsave_support_level() {
-        int cpu_info[4] = { -1 };
+        int cpu_info[4];
         __cpuid(cpu_info, 1);
 
         bool fxsave_support = cpu_info[2] & BITS_FXSAVE;

--- a/src/utility/hook.cpp
+++ b/src/utility/hook.cpp
@@ -120,8 +120,7 @@ namespace hook
         return xsave_state_buf;
     }
     
-    void init_shell_args(PVOID callback, PVOID trampoline)
-    {
+    void init_shell_args(PVOID callback, PVOID trampoline) {
         /* Get the FXSAVE/XSAVE support level */
         const uint64_t xsave_support_level = get_xsave_support_level();
         /* Get the size of the FXSAVE/XSAVE area */

--- a/src/utility/hook.cpp
+++ b/src/utility/hook.cpp
@@ -84,18 +84,18 @@ namespace hook
     }
 
    uint64_t get_xsave_support_level() {
-        int cpuInfo[4] = { -1 };
-        __cpuid(cpuInfo, 1);
+        int cpu_info[4] = { -1 };
+        __cpuid(cpu_info, 1);
 
-        bool fxsave = cpuInfo[2] & BITS_FXSAVE;
-        bool osxsave = cpuInfo[2] & BITS_OSXSAVE;
+        bool fxsave_support = cpu_info[2] & BITS_FXSAVE;
+        bool osxsave_support = cpu_info[2] & BITS_OSXSAVE;
 
-        if (osxsave) {
+        if (osxsave_support) {
             unsigned long long xcr_feature_mask = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
-            osxsave = (xcr_feature_mask & XCR0_AVX_SUPPORT) == XCR0_AVX_SUPPORT;
+            osxsave_support = (xcr_feature_mask & XCR0_AVX_SUPPORT) == XCR0_AVX_SUPPORT;
         }
 
-        return static_cast<uint64_t>(osxsave ? XSAVE_SUPPORTED : fxsave ? XSAVE_LEGACY_SSE_ONLY : XSAVE_NOT_SUPPORTED);
+        return static_cast<uint64_t>(osxsave_support ? XSAVE_SUPPORTED : fxsave_support ? XSAVE_LEGACY_SSE_ONLY : XSAVE_NOT_SUPPORTED);
     }
 
     size_t get_xsave_state_size(uint64_t xsave_support_level) {

--- a/src/utility/hook.cpp
+++ b/src/utility/hook.cpp
@@ -14,50 +14,6 @@ extern "C" {
 
 namespace hook
 {
-    /*
-    ; Pointer[0] = Whether support for XSAVE is available
-    ; Pointer[1] = Size required for saved FPU state using FXSAVE
-    ; Pointer[2] = Address of callback function
-    ; Pointer[3] = Address of next hook
-    ; Pointer[4] = Allocation of saved FPU state using FXSAVE
-    */
-
-    /*const unsigned int bit_XSAVE = 0x04000000;
-    const unsigned int bit_FXSAVE = 0x00000001;
-    const unsigned int bit_OSXSAVE = 0x08000000;*/
-
-    int fxsave_required_size() {
-        int cpu_info[4];
-        __cpuid(cpu_info, 0x80000001);
-        return (cpu_info[3] & 0x30) ? 512 : ((cpu_info[3] & 0x2) ? 256 : ((cpu_info[3] & 0x1) ? 128 : 0));
-    }
-
-    // Determines the required size of the FXSAVE/XSAVE area on the stack.
-    /*uint64_t get_fxsave_xsave_size() {
-        int cpu_info[4];
-        __cpuidex(cpu_info, 0x0D, 0);
-        return static_cast<uint64_t>(cpu_info[1]);
-    }
-
-    // Returns the level of XSAVE support:
-    // 0 = Neither XSAVE nor FXSAVE supported (if this is the case then you may as well throw an exception because the CPU is ancient)
-    // 1 = FXSAVE supported
-    // 2 = XSAVE and OSXSAVE supported
-    uint64_t get_xsave_support_level() {
-        int cpu_info[4];
-        __cpuid(cpu_info, 1);
-
-        // Both CPU and OS support the xsave instruction.
-        if ((cpu_info[2] & bit_XSAVE) && (cpu_info[2] & bit_OSXSAVE))
-            return 2ULL;
-
-        // The CPU supports the fxsave instruction.
-        if (cpu_info[3] & bit_FXSAVE)
-            return 1ULL;
-
-        return 0ULL;
-    }*/
-
     // Simple RAII wrapper for VirtualProtect.
     struct ScopedVirtualProtect {
         ScopedVirtualProtect(void* Addr, size_t Size, DWORD NewProtect) : Addr(Addr), Size(Size) { VirtualProtect(Addr, Size, NewProtect, &OldProtect); }
@@ -68,16 +24,112 @@ namespace hook
         DWORD OldProtect;
     };
 
-    // The first 'jhook_shellcode_numelems' pointer elements are at the very top of the 'jhook_shellcode_stub' function.
-    // This will set those elements to the correct values.
+    // The naked shell has an array of pointers embedded at the start, prior to the first instruction, which are used as arguments in the shellcode
+    // This function will set those embedded arguments, in order, to the values passed in the variadic template
+    // Note that 'Pointer[4]' does not need to be passed as it's set by the shellcode itself
+    /*
+        Pointer[0] = Support level of FXSAVE/XSAVE (0 = None, 1 = FXSAVE, 2 = XSAVE)
+        Pointer[1] = Buffer to be used for saving/restoring FPU state (nullptr if support level is 0)
+        Pointer[2] = Address of callback function
+        Pointer[3] = Address of next hook
+        Pointer[4] = Saved (potentially unaligned) stack pointer after preserving all registers but prior to alignment
+    */
     template<typename... TArgs>
-    void jhook_shellcode_setargs(TArgs... Args) {
+    void jhook_shellcode_setargs(TArgs... args) {
         ScopedVirtualProtect vp(jhook_shellcode_stub, 0x1, PAGE_EXECUTE_READWRITE);
 
-        uint8_t* pbFunc = (uint8_t*)jhook_shellcode_stub;
-        uintptr_t* pArgs[] = { (uintptr_t*)&Args... };
-        for (int i = 0; i < jhook_shellcode_numelems(); ++i)
-            *(uintptr_t*)(pbFunc + i * sizeof(uintptr_t)) = *pArgs[i];
+        const auto jhook_setarg = [](uint8_t*& pbFunc, const auto& arg) {
+            std::memcpy(pbFunc, &arg, sizeof(arg));
+            pbFunc += sizeof(arg);
+        };
+
+        uint8_t* pbFunc = reinterpret_cast<uint8_t*>(jhook_shellcode_stub);
+        (jhook_setarg(pbFunc, args), ...);
+    }
+
+   enum CPUID_XSAVE_BITS {
+        BITS_FXSAVE = 1 << 24,
+        BITS_XSAVE = 1 << 26,
+        BITS_OSXSAVE = 1 << 27
+    };
+
+    enum XCRO_FEATURE_MASK_BITS {
+        XCR0_SSE_BIT = 1 << 1, // Supports XMM registers
+        XCR0_AVX_BIT = 1 << 2, // Supports YMM registers
+        
+        XCR0_AVX_SUPPORT = (XCR0_SSE_BIT | XCR0_AVX_BIT)
+    };
+
+   enum XSAVE_SUPPORT_LEVEL {
+        XSAVE_NOT_SUPPORTED = 0,
+        XSAVE_LEGACY_SSE_ONLY = 1,
+        XSAVE_SUPPORTED = 2
+    };
+
+    enum XSAVE_ALIGNMENT_SIZE {
+        FXSAVE_ALIGNMENT = 16,
+        XSAVE_ALIGNMENT = 64
+    };
+
+    size_t fxsave_required_size() {
+        int cpu_info[4];
+        __cpuid(cpu_info, 0x80000001);
+        return static_cast<size_t>(cpu_info[3] & 0x30) ? 512 : ((cpu_info[3] & 0x2) ? 256 : ((cpu_info[3] & 0x1) ? 128 : 0));
+    }
+
+    size_t xsave_required_size() {
+        int cpu_info[4];
+        __cpuidex(cpu_info, 0x0D, 0);
+        return static_cast<size_t>(cpu_info[1]);
+    }
+
+   uint64_t get_xsave_support_level() {
+        int cpuInfo[4] = { -1 };
+        __cpuid(cpuInfo, 1);
+
+        bool fxsave = cpuInfo[2] & BITS_FXSAVE;
+        bool osxsave = cpuInfo[2] & BITS_OSXSAVE;
+
+        if (osxsave) {
+            unsigned long long xcrFeatureMask = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+            osxsave = (xcrFeatureMask & XCR0_AVX_SUPPORT) == XCR0_AVX_SUPPORT;
+        }
+
+        return static_cast<uint64_t>(osxsave ? XSAVE_SUPPORTED : fxsave ? XSAVE_LEGACY_SSE_ONLY : XSAVE_NOT_SUPPORTED);
+    }
+
+    size_t get_xsave_state_size(uint64_t xsave_support_level) {
+        switch (xsave_support_level) {
+        case XSAVE_SUPPORTED:
+            return xsave_required_size();
+        case XSAVE_LEGACY_SSE_ONLY:
+            return fxsave_required_size();
+        default:
+            return 0ULL;
+        }
+    }
+
+    void* alloc_xsave_state(uint64_t xsave_support_level, size_t xsave_state_len) {
+        const size_t xsave_state_align = (xsave_support_level == XSAVE_SUPPORTED ? XSAVE_ALIGNMENT : FXSAVE_ALIGNMENT);
+        void* xsave_state_buf = (xsave_support_level != XSAVE_NOT_SUPPORTED ? _aligned_malloc(xsave_state_len, xsave_state_align) : nullptr);
+
+        /* Zero out the FPU state buffer */
+        if (xsave_state_buf != nullptr)
+            memset(xsave_state_buf, 0, xsave_state_len);
+
+        return xsave_state_buf;
+    }
+    
+    void init_shell_args(PVOID callback, PVOID trampoline)
+    {
+        /* Get the FXSAVE/XSAVE support level */
+        const uint64_t xsave_support_level = get_xsave_support_level();
+        /* Get the size of the FXSAVE/XSAVE area */
+        const size_t xsave_state_len = get_xsave_state_size(xsave_support_level);
+        /* Allocate an aligned buffer for the preserved FPU state */
+        void* fpu_state_buf = alloc_xsave_state(xsave_support_level, xsave_state_len);
+        /* Set the arguments for the shellcode */
+        jhook_shellcode_setargs(xsave_support_level, fpu_state_buf, callback, trampoline);
     }
 }
 
@@ -215,19 +267,6 @@ namespace hook
         size = trampoline.size( );
 
         return trampoline_address;
-    }
-
-    // TODO: Add support for XSAVE, reverting to FXSAVE for now
-    void init_shell_args( PVOID callback, PVOID trampoline )
-    {
-        /* Get the size of the FXSAVE/XSAVE area */
-        uint64_t fxsave_xsave_size = fxsave_required_size( );
-        /* Get the XSAVE support level */
-        uint64_t xsave_support_level = get_xsave_support_level( );
-        /* Allocate space for FPU state via FXSAVE */
-        void* addr = _aligned_malloc(fxsave_xsave_size, 16);
-        /* Set the arguments for the shellcode */
-        jhook_shellcode_setargs( xsave_support_level, fxsave_xsave_size, callback, trampoline, addr );
     }
 
     void* create_naked_shell( PVOID callback, PVOID trampoline )

--- a/src/utility/hook.cpp
+++ b/src/utility/hook.cpp
@@ -38,13 +38,13 @@ namespace hook
     void jhook_shellcode_setargs(TArgs... args) {
         ScopedVirtualProtect vp(jhook_shellcode_stub, 0x1, PAGE_EXECUTE_READWRITE);
 
-        const auto jhook_setarg = [](uint8_t*& pbFunc, const auto& arg) {
-            std::memcpy(pbFunc, &arg, sizeof(arg));
-            pbFunc += sizeof(arg);
+        const auto jhook_setarg = [](uint8_t*& args_addr, const auto& arg) {
+            std::memcpy(args_addr, &arg, sizeof(arg));
+            args_addr += sizeof(uintptr_t);
         };
 
-        uint8_t* pbFunc = reinterpret_cast<uint8_t*>(jhook_shellcode_stub);
-        (jhook_setarg(pbFunc, args), ...);
+        uint8_t* args_addr = reinterpret_cast<uint8_t*>(jhook_shellcode_stub);
+        (jhook_setarg(args_addr, args), ...);
     }
 
    enum CPUID_XSAVE_BITS {
@@ -91,8 +91,8 @@ namespace hook
         bool osxsave = cpuInfo[2] & BITS_OSXSAVE;
 
         if (osxsave) {
-            unsigned long long xcrFeatureMask = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
-            osxsave = (xcrFeatureMask & XCR0_AVX_SUPPORT) == XCR0_AVX_SUPPORT;
+            unsigned long long xcr_feature_mask = _xgetbv(_XCR_XFEATURE_ENABLED_MASK);
+            osxsave = (xcr_feature_mask & XCR0_AVX_SUPPORT) == XCR0_AVX_SUPPORT;
         }
 
         return static_cast<uint64_t>(osxsave ? XSAVE_SUPPORTED : fxsave ? XSAVE_LEGACY_SSE_ONLY : XSAVE_NOT_SUPPORTED);

--- a/src/utility/naked_hook.asm
+++ b/src/utility/naked_hook.asm
@@ -118,8 +118,7 @@ restore_fpu_state_xsave MACRO
 ENDM
 
 ; Macro for simplifying the use of saving and restoring the FPU state
-;   Arg0: Pointer to the dynamic array of values used by the shellcode
-;   Arg1: Constant 0/1 to indicate whether to save or restore the FPU state
+;   Arg: Constant 0/1 to indicate whether to save or restore the FPU state
 preserve_fpu_state MACRO restoring
     ; Make sure all the labels are local
     Local fpu_preserve_fxsave, fpu_preserve_xsave, fpu_preserve_end

--- a/src/utility/naked_hook.asm
+++ b/src/utility/naked_hook.asm
@@ -2,7 +2,7 @@
 ; Pointer[1] = Size required for saved FPU state using XSAVE or FXSAVE
 ; Pointer[2] = Address of callback function
 ; Pointer[3] = Address of next hook
-SHELL_PTR_ELEMS EQU 4
+SHELL_PTR_ELEMS EQU 5
 SHELL_ENDCODE_MAGIC EQU 02BAD4B0BBAADBABEh
 
 ; Macro for preserving all general purpose registers
@@ -158,6 +158,12 @@ jhook_shellcode_stub PROC
     save_cpu_state_gpr
     ; save_fpu_state dyn_addr_arr
 
+    ; Save FPU State
+    push r15
+    mov r15, qword ptr [dyn_addr_arr + 20h]
+    fxsave [r15]
+    pop r15
+
     ; Prepare for the subroutine call
     mov rcx, rsp
     
@@ -170,6 +176,12 @@ jhook_shellcode_stub PROC
     
     ; Deallocate the space on the stack
     add rsp, 28h
+
+    ; Restore FPU State
+    push r15
+    mov r15, qword ptr [dyn_addr_arr + 20h]
+    fxrstor [r15]
+    pop r15
 
     ; Restore the registers, flags, and FPU state
     restore_cpu_state_gpr


### PR DESCRIPTION
Assembly code has been pretty heavily refactored and commented. It now supports FPU state preservation with XSAVE (full) when CPU/OS supported, falling back to FXSAVE (x87/SSE2) if CPU supported. I also refactored some of the code in hooks.cpp to make things a bit cleaner and easier to understand. Fixed a couple bugs in both files, read the comments I added for more details.