### PR TITLE
Refactored

### DIFF
--- a/include/utility/hook.hpp
+++ b/include/utility/hook.hpp
@@ -9,6 +9,7 @@
 
 struct hook_context
 {
+    uintptr_t skip_original_call;
     uintptr_t flags;
     uintptr_t r15;
     uintptr_t r14;


### PR DESCRIPTION
- Renamed some of the labels and embedded arguments in assembly to better reflect what they do
- Added a new argument to the callback context for skipping the original function
- Updated restore_cpu_state to pop rax as well to keep things uniform, the additional argument is now pushed, read, and restored within jhook_shellcode_stub directly